### PR TITLE
feat(build): add build system

### DIFF
--- a/test.c
+++ b/test.c
@@ -1,0 +1,6 @@
+#include <stdio.h>
+
+int main(int argc, char** argv) {
+    printf( "You'll never run me I'm compiled for ARM\n");
+    return -1;
+}

--- a/tools/Dockerfile
+++ b/tools/Dockerfile
@@ -1,0 +1,42 @@
+FROM python:3.10-slim-bullseye
+MAINTAINER Opentrons Engineering <engineering@opentrons.com>
+
+ARG HOST_USER_ID=1000
+ARG HOST_GROUP_ID=1000
+
+
+ENV BUILDENV_ROOT=/build-environment
+ENV POETRY_HOME=/build-environment/poetry
+ENV POETRY_VERSION=1.2.1
+ENV PATH=$PATH:/build-environment/poetry/bin
+ENV POETRY_VIRTUALENVS_IN_PROJECT=true
+ENV HOME=/build-environment
+
+RUN apt update && apt install -y curl wget file
+RUN mkdir -p /${POETRY_HOME}/poetry \
+    && chown -R ${HOST_USER_ID} //build-environment
+RUN rm /bin/sh && ln -s /bin/bash /bin/sh
+USER ${HOST_USER_ID}:${HOST_GROUP_ID}
+
+WORKDIR /build-environment
+
+VOLUME /build-environment/python-package-index
+
+RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN poetry self add "poetry-dynamic-versioning[plugin]"
+RUN poetry self add 'poethepoet[poetry_plugin]'
+
+# TODO: This should be a release version of the SDK, but one does not
+# exist yet.
+RUN \
+    cd /build-environment \
+    && wget https://opentrons-buildroot-ci.s3.amazonaws.com/439bccec-fff5-4501-9074-f463408da59a/opentrons-buildroot/arm-buildroot-linux-gnueabihf_sdk-buildroot.tar.gz \
+    && tar xf ./arm-buildroot-linux-gnueabihf_sdk-buildroot.tar.gz \
+    && cd arm-buildroot-linux-gnueabihf_sdk-buildroot \
+    && ./relocate-sdk.sh
+
+ADD . .
+RUN cd /build-environment \
+   && poetry install
+
+ENTRYPOINT ["poetry", "run", "run-build-internal", "--package-repo-base=/build-environment/python-package-index", "--buildroot-sdk-base=/build-environment/arm-buildroot-linux-gnueabihf_sdk-buildroot"]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,23 @@
+# Build Tools
+
+This subdirectory holds the local build tools we use for building the python packages. They are responsible for build orchestration and kicking off everything.
+
+This tooling uses [poetry](python-poetry.org) with some plugins:
+- [poetry-dynamic-versioning](https://pypi.org/project/poetry-dynamic-versioning/). to take versions from git
+- [poe-the-poet](https://pypi.org/project/poethepoet/) to run tasks like test
+
+You don't need to install these to _use_ the tooling - docker takes care of that - but you do need to install them to _change_ the tooling.
+
+You do need to install docker for your preferred platform.
+
+## Using Poetry
+
+Because we use poe, we can get away without having a wrapping makefile for dev tasks.
+
+You can
+
+- *set up*: using `poetry install`
+- *lint*: using `poetry poe lint`
+- *format*: using `poetry poe format`
+- *test*: using `poetry poe test`
+- *try a build*: using `poetry run builder.host.run`

--- a/tools/builder/__init__.py
+++ b/tools/builder/__init__.py
@@ -1,0 +1,17 @@
+"""
+builder: the package that builds the packages
+
+Because the package build system is complex and is in a python ecosystem, we
+use python for our build orchestration. The build orchestration system all
+lives here.
+
+KEEP THIS FILE AND ITS IMPORTS FREE OF EXTERNAL DEPENDENCIES. This package is
+used both inside the container, where it's okay to use whatever you want as long
+as it's in poetry; and outside the container, where we really want to let people
+run the builder using only a base python install and docker. Code in builder.common
+or builder.host must be runnable in this way, and importing builder.host or
+builder.common will run whatever code is in this file. Any other subpackage is
+fair game.
+"""
+
+__version__ = "0.0.0"

--- a/tools/builder/common/__init__.py
+++ b/tools/builder/common/__init__.py
@@ -1,0 +1,7 @@
+"""
+builder.common: code shared between host and container sides.
+
+Code here MUST NOT import any python library not in the standard library. We
+want this common code to exist so it can centralize things like arguments, but
+it needs to be callable outside the poetry environment, so it can't use dependencies.
+"""

--- a/tools/builder/common/args.py
+++ b/tools/builder/common/args.py
@@ -1,0 +1,21 @@
+"""common.args: common code that builds arguments"""
+
+import sys
+import argparse
+
+
+def add_common_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    parser.add_argument(
+        "--output",
+        "-o",
+        action="store",
+        type=argparse.FileType("w"),
+        default=sys.stdout,
+        help="Where to write build logging output (- for stdout)",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Whether verbose output should be written",
+    )
+    return parser

--- a/tools/builder/container/__init__.py
+++ b/tools/builder/container/__init__.py
@@ -1,0 +1,7 @@
+"""
+builder.container: code for what happens inside the container
+"""
+
+from .run import run_build, run_from_cmdline
+
+__all__ = ["run_build", "run_from_cmdline"]

--- a/tools/builder/container/run.py
+++ b/tools/builder/container/run.py
@@ -1,0 +1,124 @@
+"""
+builder.container.run: run the build inside a container
+"""
+import argparse
+import io
+import subprocess
+from pathlib import Path
+from builder.common import args
+
+
+def run_from_cmdline() -> None:
+    """
+    Run the build as a main function from a command line call.
+
+    That means it may write to sys.stdout and may call sys.exit.
+    """
+    parser = argparse.ArgumentParser("Build the packages.")
+    parser.add_argument(
+        "--package-repo-base",
+        type=str,
+        help="Path to the build environment inside the container",
+    )
+    parser.add_argument(
+        "--buildroot-sdk-base",
+        type=str,
+        help="Path to the downloaded and relocated sdk",
+    )
+    parser = args.add_common_args(parser)
+    parsed_args = parser.parse_args()
+    run_build(
+        Path(parsed_args.package_repo_base),
+        Path(parsed_args.buildroot_sdk_base),
+        parsed_args.output,
+        parsed_args.verbose,
+    )
+
+
+def _envmap_from_printenv(printenv_result: str) -> dict[str, str]:
+    printenv_lines = iter(printenv_result.split("\n"))
+    while next(printenv_lines).strip() != "__OT_OUTPUT__":
+        continue
+    environ_map: dict[str, str] = {}
+    for line in printenv_lines:
+        thisline = line.strip()
+        if not thisline:
+            continue
+        lineparts = thisline.split("=")
+        environ_map[lineparts[0]] = "=".join(lineparts[1:])
+    return environ_map
+
+
+def activate_environment(
+    buildroot_sdk_base: Path, output: io.TextIOBase, verbose: bool
+) -> dict[str, str]:
+    print("Capturing buildroot SDK environment", file=output)
+    cmd = [
+        "/bin/bash",
+        "-c",
+        f'. {str(buildroot_sdk_base / "environment-setup")} && echo __OT_OUTPUT__ && printenv',
+    ]
+    if verbose:
+        print(" ".join(cmd), file=output)
+    result = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Buildroot SDK environment activation failed: {result.returncode}: {result.stderr} {result.stdout}"
+        )
+    if verbose:
+        print(result.stdout, file=output)
+    environ_map = _envmap_from_printenv(result.stdout)
+    if verbose:
+        print(f"Harvested buildroot SDK environ vars: {environ_map}", file=output)
+    return environ_map
+
+
+def run_build(
+    package_repo_base: Path,
+    buildroot_sdk_base: Path,
+    output: io.TextIOBase,
+    verbose: bool,
+) -> None:
+    """Run the build."""
+    environ = activate_environment(buildroot_sdk_base, output, verbose)
+    testfile = package_repo_base / "test.c"
+    print(f"Building tiny little test file: {testfile.open().read()}", file=output)
+    # It appears that PATH has to be set like this every time for reasons that escape me
+    compile_args = [
+        f'PATH={environ["PATH"]}',
+        "$CC",
+        "$CFLAGS",
+        str(package_repo_base / "test.c"),
+        "-o",
+        str(package_repo_base / "test.out"),
+    ]
+    if verbose:
+        print(" ".join(compile_args))
+    result = subprocess.run(
+        compile_args,
+        cwd=str(package_repo_base),
+        shell=True,
+        env=environ,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if verbose:
+        print(result.stdout, file=output)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Compile failed: {result.returncode}: {result.stdout!r}: {result.stderr!r}"
+        )
+    check_args = ["file", str(package_repo_base / "test.out")]
+    if verbose:
+        print(" ".join(check_args))
+    result = subprocess.run(check_args, check=True, capture_output=True)
+    print(result.stdout, file=output)
+    assert b"ARM" in result.stdout
+
+
+if __name__ == "__main__":
+    run_from_cmdline()

--- a/tools/builder/host/__init__.py
+++ b/tools/builder/host/__init__.py
@@ -1,0 +1,12 @@
+"""
+builder.host: the host side of the build tooling
+
+This code runs outside the container, and probably outside the virtualenv.
+It MUST NOT contain external dependencies so that it can be easily run
+by anybody - the real action happens inside the container. Keep this code
+minimal.
+"""
+
+from .run import run_build, run_from_cmdline
+
+__all__ = ["run_build", "run_from_cmdline"]

--- a/tools/builder/host/run.py
+++ b/tools/builder/host/run.py
@@ -1,0 +1,157 @@
+"""external.run: interface for running the build from host shell"""
+import argparse
+import subprocess
+import os
+import sys
+import io
+
+from typing import List
+
+import builder.common.args
+import builder
+
+ROOT_PATH = os.path.realpath(
+    os.path.join(os.path.dirname(builder.__file__), os.path.pardir)
+)
+VOLUME_PATH = os.path.realpath(os.path.join(ROOT_PATH, os.path.pardir))
+
+
+def run_from_cmdline() -> None:
+    """
+    Run as the main function from commandline.
+
+    This function may write to stdout, and will swallow all exceptions and sys.exit
+    if it gets them. It will also sys.exit if it succeeds. It should be called only
+    from a command line wrapper.
+    """
+    parser = build_arg_parser()
+    args = parser.parse_args()
+    try:
+        run_build(sys.argv, args, allow_sys_exit=True)
+    except Exception as exc:
+        if args.verbose:
+            import traceback
+
+            print("\n".join(traceback.format_exception(exc)), file=args.output)
+        else:
+            print(f"Build failed: {str(exc)}", file=args.output)
+
+
+def run_build(
+    argv: List[str], parsed_args: argparse.Namespace, /, allow_sys_exit: bool = False
+) -> None:
+    """
+    Primary external interface - run the build.
+
+    Parameters:
+    argv: The sys.argv that should be used inside the container. In almost all cases
+          this should be sys.argv.
+    parsed_args: The result of calling build_arg_parser.parse_args(). This needs to
+                 happen outside this function since if -h/--help is in the args, argparse
+                 "helpfully" prints help and exits.
+    allow_sys_exit (kw only): Allow this call to call sys.exit(). This is useful in a
+                              direct command-line context and to be avoided otherwise.
+    """
+    container_str = _build_container(
+        os.geteuid(), os.getegid(), parsed_args.output, allow_sys_exit
+    )
+    _run_build(container_str, argv[1:], parsed_args.output)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build and return the common arguments used both inside and outside the container."""
+    parser = argparse.ArgumentParser(description="Build the packages in this repo.")
+    parser = builder.common.args.add_common_args(parser)
+    return parser
+
+
+def _container_image_name() -> str:
+    return f"opentrons-python-packages-{builder.__version__}"
+
+
+def _container_build_invoke_cmd(effective_uid: int, effective_gid: int) -> List[str]:
+    """Create the string used to invoke the container build"""
+    return [
+        "docker",
+        "build",
+        f"--build-arg=HOST_USER_ID={effective_uid}",
+        f"--build-arg=HOST_GROUP_ID={effective_gid}",
+        "-f",
+        os.path.join(ROOT_PATH, "Dockerfile"),
+        "-t",
+        f"{_container_image_name()}",
+        ROOT_PATH,
+    ]
+
+
+def _build_container(
+    effective_uid: int, effective_gid: int, output: io.TextIOBase, allow_sys_exist: bool
+) -> str:
+    """Build the docker container and return a keyword usable to run it."""
+    invoke_str = _container_build_invoke_cmd(effective_uid, effective_gid)
+    print("Creating container", file=output)
+    print(" ".join(invoke_str), file=output)
+    proc = subprocess.Popen(
+        invoke_str,
+        bufsize=100,
+        cwd=ROOT_PATH,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if not proc.stdout:
+        raise RuntimeError("failed to communicate with builder process")
+    try:
+        while proc.poll() is None:
+            output.write(proc.stdout.read().decode())
+            output.flush()
+    except KeyboardInterrupt:
+        proc.terminate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"Container build failed with {proc.returncode}")
+    print(f"Created container as {_container_image_name()}", file=output)
+    return _container_image_name()
+
+
+def _container_run_invoke_cmd(
+    container_str: str, forwarded_argv: List[str]
+) -> List[str]:
+    """Build the string to run the container."""
+    return [
+        "docker",
+        "run",
+        "--rm",
+        f"--volume={VOLUME_PATH}:/build-environment/python-package-index:rw,delegated",
+        container_str,
+    ] + forwarded_argv
+
+
+def _run_build(
+    container_str: str,
+    forwarded_argv: List[str],
+    output: io.TextIOBase,
+    allow_sys_exit: bool = False,
+) -> None:
+    print("Running build", file=output)
+    invoke_str = _container_run_invoke_cmd(container_str, forwarded_argv)
+    print(" ".join(invoke_str), file=output)
+    proc = subprocess.Popen(
+        invoke_str,
+        bufsize=100,
+        cwd=ROOT_PATH,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    if not proc.stdout:
+        raise RuntimeError("failed to communicate with builder process")
+    try:
+        while proc.poll() is None:
+            output.write(proc.stdout.read().decode())
+            output.flush()
+    except KeyboardInterrupt:
+        proc.terminate()
+    if proc.returncode != 0:
+        raise RuntimeError(f"Build failed with {proc.returncode}")
+
+
+if __name__ == "__main__":
+    run_from_cmdline()

--- a/tools/poetry.lock
+++ b/tools/poetry.lock
@@ -1,0 +1,386 @@
+[[package]]
+name = "attrs"
+version = "22.1.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy (>=0.900,!=0.940)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy (>=0.900,!=0.940)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins"]
+
+[[package]]
+name = "black"
+version = "22.8.0"
+description = "The uncompromising code formatter."
+category = "dev"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+click = ">=8.0.0"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.9.0"
+platformdirs = ">=2"
+tomli = {version = ">=1.1.0", markers = "python_full_version < \"3.11.0a7\""}
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.7.4)"]
+jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
+uvloop = ["uvloop (>=0.15.2)"]
+
+[[package]]
+name = "click"
+version = "8.1.3"
+description = "Composable command line interface toolkit"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "colorama"
+version = "0.4.5"
+description = "Cross-platform colored terminal text."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "flake8"
+version = "5.0.4"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = ">=3.6.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.9.0,<2.10.0"
+pyflakes = ">=2.5.0,<2.6.0"
+
+[[package]]
+name = "flake8-noqa"
+version = "1.2.9"
+description = "Flake8 noqa comment validation"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+flake8 = ">=3.8.0,<6.0"
+typing-extensions = ">=3.7.4.2"
+
+[package.extras]
+dev = ["flake8 (>=3.8.0,<5.0)", "flake8-annotations", "flake8-bandit", "flake8-bugbear", "flake8-commas", "flake8-comprehensions", "flake8-continuation", "flake8-datetimez", "flake8-docstrings", "flake8-import-order", "flake8-literal", "flake8-modern-annotations", "flake8-noqa", "flake8-polyfill", "flake8-requirements", "flake8-tabs", "flake8-typechecking-import", "flake8-use-fstring", "mypy", "pep8-naming"]
+
+[[package]]
+name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mccabe"
+version = "0.7.0"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "mypy"
+version = "0.971"
+description = "Optional static typing for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+mypy-extensions = ">=0.4.3"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "0.4.3"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
+
+[[package]]
+name = "pathspec"
+version = "0.10.1"
+description = "Utility library for gitignore style pattern matching of file paths."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "platformdirs"
+version = "2.5.2"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
+
+[[package]]
+name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.9.1"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyflakes"
+version = "2.5.0"
+description = "passive checker of Python programs"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "pyparsing"
+version = "3.0.9"
+description = "pyparsing module - Classes and methods to define and execute parsing grammars"
+category = "dev"
+optional = false
+python-versions = ">=3.6.8"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
+
+[[package]]
+name = "pyproject-flake8"
+version = "5.0.4.post1"
+description = "pyproject-flake8 (`pflake8`), a monkey patching wrapper to connect flake8 with pyproject.toml configuration"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+flake8 = "5.0.4"
+tomli = {version = "*", markers = "python_version < \"3.11\""}
+
+[[package]]
+name = "pytest"
+version = "7.1.3"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=0.12,<2.0"
+py = ">=1.8.2"
+tomli = ">=1.0.0"
+
+[package.extras]
+testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
+
+[[package]]
+name = "tomli"
+version = "2.0.1"
+description = "A lil' TOML parser"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "typing-extensions"
+version = "4.3.0"
+description = "Backported and Experimental Type Hints for Python 3.7+"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.10"
+content-hash = "da4e3e70cd8d9e0a5cc779f339a907c0f32191ac222905bfde699a67276d16f2"
+
+[metadata.files]
+attrs = [
+    {file = "attrs-22.1.0-py2.py3-none-any.whl", hash = "sha256:86efa402f67bf2df34f51a335487cf46b1ec130d02b8d39fd248abfd30da551c"},
+    {file = "attrs-22.1.0.tar.gz", hash = "sha256:29adc2665447e5191d0e7c568fde78b21f9672d344281d0c6e1ab085429b22b6"},
+]
+black = [
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:ce957f1d6b78a8a231b18e0dd2d94a33d2ba738cd88a7fe64f53f659eea49fdd"},
+    {file = "black-22.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5107ea36b2b61917956d018bd25129baf9ad1125e39324a9b18248d362156a27"},
+    {file = "black-22.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e8166b7bfe5dcb56d325385bd1d1e0f635f24aae14b3ae437102dedc0c186747"},
+    {file = "black-22.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd82842bb272297503cbec1a2600b6bfb338dae017186f8f215c8958f8acf869"},
+    {file = "black-22.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:d839150f61d09e7217f52917259831fe2b689f5c8e5e32611736351b89bb2a90"},
+    {file = "black-22.8.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a05da0430bd5ced89176db098567973be52ce175a55677436a271102d7eaa3fe"},
+    {file = "black-22.8.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a098a69a02596e1f2a58a2a1c8d5a05d5a74461af552b371e82f9fa4ada8342"},
+    {file = "black-22.8.0-cp36-cp36m-win_amd64.whl", hash = "sha256:5594efbdc35426e35a7defa1ea1a1cb97c7dbd34c0e49af7fb593a36bd45edab"},
+    {file = "black-22.8.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a983526af1bea1e4cf6768e649990f28ee4f4137266921c2c3cee8116ae42ec3"},
+    {file = "black-22.8.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b2c25f8dea5e8444bdc6788a2f543e1fb01494e144480bc17f806178378005e"},
+    {file = "black-22.8.0-cp37-cp37m-win_amd64.whl", hash = "sha256:78dd85caaab7c3153054756b9fe8c611efa63d9e7aecfa33e533060cb14b6d16"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:cea1b2542d4e2c02c332e83150e41e3ca80dc0fb8de20df3c5e98e242156222c"},
+    {file = "black-22.8.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5b879eb439094751185d1cfdca43023bc6786bd3c60372462b6f051efa6281a5"},
+    {file = "black-22.8.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0a12e4e1353819af41df998b02c6742643cfef58282915f781d0e4dd7a200411"},
+    {file = "black-22.8.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c3a73f66b6d5ba7288cd5d6dad9b4c9b43f4e8a4b789a94bf5abfb878c663eb3"},
+    {file = "black-22.8.0-cp38-cp38-win_amd64.whl", hash = "sha256:e981e20ec152dfb3e77418fb616077937378b322d7b26aa1ff87717fb18b4875"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8ce13ffed7e66dda0da3e0b2eb1bdfc83f5812f66e09aca2b0978593ed636b6c"},
+    {file = "black-22.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:32a4b17f644fc288c6ee2bafdf5e3b045f4eff84693ac069d87b1a347d861497"},
+    {file = "black-22.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0ad827325a3a634bae88ae7747db1a395d5ee02cf05d9aa7a9bd77dfb10e940c"},
+    {file = "black-22.8.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53198e28a1fb865e9fe97f88220da2e44df6da82b18833b588b1883b16bb5d41"},
+    {file = "black-22.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:bc4d4123830a2d190e9cc42a2e43570f82ace35c3aeb26a512a2102bce5af7ec"},
+    {file = "black-22.8.0-py3-none-any.whl", hash = "sha256:d2c21d439b2baf7aa80d6dd4e3659259be64c6f49dfd0f32091063db0e006db4"},
+    {file = "black-22.8.0.tar.gz", hash = "sha256:792f7eb540ba9a17e8656538701d3eb1afcb134e3b45b71f20b25c77a8db7e6e"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
+flake8 = [
+    {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
+    {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+]
+flake8-noqa = [
+    {file = "flake8-noqa-1.2.9.tar.gz", hash = "sha256:26d92ca6b72dec732d294e587a2bdeb66dab01acc609ed6a064693d6baa4e789"},
+    {file = "flake8_noqa-1.2.9-py3-none-any.whl", hash = "sha256:445618162e0bbae1b9d983326d4e39066c5c6de71ba0c444ca2d4d1fa5b2cdb7"},
+]
+iniconfig = [
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+mccabe = [
+    {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
+    {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
+]
+mypy = [
+    {file = "mypy-0.971-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2899a3cbd394da157194f913a931edfd4be5f274a88041c9dc2d9cdcb1c315c"},
+    {file = "mypy-0.971-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:98e02d56ebe93981c41211c05adb630d1d26c14195d04d95e49cd97dbc046dc5"},
+    {file = "mypy-0.971-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:19830b7dba7d5356d3e26e2427a2ec91c994cd92d983142cbd025ebe81d69cf3"},
+    {file = "mypy-0.971-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:02ef476f6dcb86e6f502ae39a16b93285fef97e7f1ff22932b657d1ef1f28655"},
+    {file = "mypy-0.971-cp310-cp310-win_amd64.whl", hash = "sha256:25c5750ba5609a0c7550b73a33deb314ecfb559c350bb050b655505e8aed4103"},
+    {file = "mypy-0.971-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:d3348e7eb2eea2472db611486846742d5d52d1290576de99d59edeb7cd4a42ca"},
+    {file = "mypy-0.971-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3fa7a477b9900be9b7dd4bab30a12759e5abe9586574ceb944bc29cddf8f0417"},
+    {file = "mypy-0.971-cp36-cp36m-win_amd64.whl", hash = "sha256:2ad53cf9c3adc43cf3bea0a7d01a2f2e86db9fe7596dfecb4496a5dda63cbb09"},
+    {file = "mypy-0.971-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:855048b6feb6dfe09d3353466004490b1872887150c5bb5caad7838b57328cc8"},
+    {file = "mypy-0.971-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:23488a14a83bca6e54402c2e6435467a4138785df93ec85aeff64c6170077fb0"},
+    {file = "mypy-0.971-cp37-cp37m-win_amd64.whl", hash = "sha256:4b21e5b1a70dfb972490035128f305c39bc4bc253f34e96a4adf9127cf943eb2"},
+    {file = "mypy-0.971-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:9796a2ba7b4b538649caa5cecd398d873f4022ed2333ffde58eaf604c4d2cb27"},
+    {file = "mypy-0.971-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5a361d92635ad4ada1b1b2d3630fc2f53f2127d51cf2def9db83cba32e47c856"},
+    {file = "mypy-0.971-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b793b899f7cf563b1e7044a5c97361196b938e92f0a4343a5d27966a53d2ec71"},
+    {file = "mypy-0.971-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d1ea5d12c8e2d266b5fb8c7a5d2e9c0219fedfeb493b7ed60cd350322384ac27"},
+    {file = "mypy-0.971-cp38-cp38-win_amd64.whl", hash = "sha256:23c7ff43fff4b0df93a186581885c8512bc50fc4d4910e0f838e35d6bb6b5e58"},
+    {file = "mypy-0.971-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:1f7656b69974a6933e987ee8ffb951d836272d6c0f81d727f1d0e2696074d9e6"},
+    {file = "mypy-0.971-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d2022bfadb7a5c2ef410d6a7c9763188afdb7f3533f22a0a32be10d571ee4bbe"},
+    {file = "mypy-0.971-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ef943c72a786b0f8d90fd76e9b39ce81fb7171172daf84bf43eaf937e9f220a9"},
+    {file = "mypy-0.971-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:d744f72eb39f69312bc6c2abf8ff6656973120e2eb3f3ec4f758ed47e414a4bf"},
+    {file = "mypy-0.971-cp39-cp39-win_amd64.whl", hash = "sha256:77a514ea15d3007d33a9e2157b0ba9c267496acf12a7f2b9b9f8446337aac5b0"},
+    {file = "mypy-0.971-py3-none-any.whl", hash = "sha256:0d054ef16b071149917085f51f89555a576e2618d5d9dd70bd6eea6410af3ac9"},
+    {file = "mypy-0.971.tar.gz", hash = "sha256:40b0f21484238269ae6a57200c807d80debc6459d444c0489a102d7c6a75fa56"},
+]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
+packaging = [
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
+]
+pathspec = [
+    {file = "pathspec-0.10.1-py3-none-any.whl", hash = "sha256:46846318467efc4556ccfd27816e004270a9eeeeb4d062ce5e6fc7a87c573f93"},
+    {file = "pathspec-0.10.1.tar.gz", hash = "sha256:7ace6161b621d31e7902eb6b5ae148d12cfd23f4a249b9ffb6b9fee12084323d"},
+]
+platformdirs = [
+    {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
+    {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
+]
+pluggy = [
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+py = [
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
+    {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+]
+pyflakes = [
+    {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
+    {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pyproject-flake8 = [
+    {file = "pyproject-flake8-5.0.4.post1.tar.gz", hash = "sha256:c2dfdf1064f47efbb2e4faf1a32b0b6a6ea67dc4d1debb98d862b0cdee377941"},
+    {file = "pyproject_flake8-5.0.4.post1-py2.py3-none-any.whl", hash = "sha256:457e52dde1b7a1f84b5230c70d61afa58ced64a44b81a609f19e972319fa68ed"},
+]
+pytest = [
+    {file = "pytest-7.1.3-py3-none-any.whl", hash = "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7"},
+    {file = "pytest-7.1.3.tar.gz", hash = "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"},
+]
+tomli = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -1,0 +1,54 @@
+[tool.poetry]
+name = "builder"
+version = "0.0.0-post.4+e6854d9.dirty"
+description = "Builder for the opentrons python package index"
+authors = ["Opentrons Engineering <engineering@opentrons.com>"]
+readme = "README.md"
+packages = [{include = "builder"}]
+
+[tool.poetry.scripts]
+run-build='builder.host:run_from_cmdline'
+run-build-internal='builder.container.run:run_from_cmdline'
+
+[tool.poetry-dynamic-versioning]
+enable=false
+vcs="git"
+metadata=true
+dirty=true
+style="semver"
+tag-branch="main"
+pattern="default"
+
+[tool.poe.tasks]
+format = 'black .'
+test = 'py.test ./tests'
+_formatcheck = 'black --check ./builder ./tests'
+_flake8 = 'pflake8 ./builder ./tests'
+_typecheck = 'mypy ./builder ./tests'
+lint = ['_formatcheck', '_flake8', '_typecheck']
+
+[tool.poetry.dependencies]
+python = "^3.10"
+
+[tool.poetry.dev-dependencies]
+black="~=22.8.0"
+mypy="==0.971"
+flake8="~=5.0.4"
+pyproject-flake8= "~=5.0.4"
+flake8-noqa = "~=1.2.9"
+pytest = "~=7.1.3"
+
+[tool.mypy]
+show_error_codes = true
+warn_unused_configs = true
+strict = true
+no_implicit_optional = true
+warn_return_any = true
+
+[tool.flake8]
+max-complexity = 9
+extend-ignore = ["E203","E501", "ANN101", "ANN102"]
+
+[build-system]
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"

--- a/tools/tests/builder/hosts/test_run.py
+++ b/tools/tests/builder/hosts/test_run.py
@@ -1,0 +1,17 @@
+import os
+from builder.host import run
+
+
+def test_container_build_invoker() -> None:
+    invoke_str = run._container_build_invoke_cmd(25, 12)
+    assert "--build-arg=HOST_USER_ID=25" in invoke_str
+    assert "--build-arg=HOST_GROUP_ID=12" in invoke_str
+    assert os.path.exists(next((arg for arg in invoke_str if "Dockerfile" in arg)))
+
+
+def container_run_invoker() -> None:
+    args = ["arg1", "arg2", "arg with spaces"]
+    invoke_str = run._container_run_invoke_cmd("my-cool-container", args)
+    assert "my-cool-container" in invoke_str
+    for arg in args:
+        assert arg in invoke_str

--- a/tools/tests/conftest.py
+++ b/tools/tests/conftest.py
@@ -1,0 +1,1 @@
+"""Conftest for all builder tests"""


### PR DESCRIPTION
We'll build python packages (eventually) by running standard wheel builds in a correct environment, provided by a buildroot SDK. The buildroot SDK's environment will overwrite the current environment because it gets sourced. In interactive contexts, you can just close that shell when you're done, but we need to isolate further. Therefore, we need a docker container.

This docker container provides a python environment so we can run python build orchestration, but its big job is to
- Download the buildroot SDK (from our S3, where it is now a build output of our buildroot)
- Contain the environment variable stuff that the SDK does within it

With this orchestration, we can do that.

We'll provide a python package of our own called `builder` (bad name if it was published, but it's not) that has two entrypoints: a host entry point that can be called to initiate a build and is vaguely cross-python-version compatible, and a container entrypoint that runs inside the container to execute the build. The host entrypoint builds and runs the container (and is called from a quick script at the top of the repo), and the container entrypoint for now activates the buildroot environment and builds a test c file to prove that it gets the right architecture.

Closes RCORE-208

## TODO
- [ ] Update readmes
- [ ] add GH workflows to build stuff
- [ ] put the container somewhere because it takes a while to build, annoyingly
- [ ] separate orchestration version from everything else's version to support the above

## Review request
Give it a try, particularly on mac. It works nice and repeatedly for me on linux at least. Let me know if it's insanely slow.