### PR TITLE
tools: properly set urls from index paths

### DIFF
--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -83,16 +83,46 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: 'Check package build'
     needs: [python_check]
+    outputs:
+      target-url: steps.set-url.outputs.target-url
     steps:
+      - id: set-url
+        run: |
+          echo "::set-output name=target-url::https://dev.pypi.opentrons.com"
       - uses: 'actions/checkout@v3'
       - uses: 'actions/setup-python@v4'
         with:
           python-version: '3.10'
       - name: 'Run the build'
         run: |
-          ./build-packages --container-source=build --verbose
+          ./build-packages --container-source=build --verbose --index-root-url=${{steps.set-url.outputs.target-url}}/${{github.ref_name}}
       - name: 'Upload artifacts to temporary storage'
         uses: 'actions/upload-artifact@v3'
         with:
-          name: "opentrons-python-packages"
+          name: "package-dist"
           path: "dist/**/*"
+      - name: "Upload index to temporary storage"
+        uses: 'actions/upload-artifact@v3'
+        with:
+          name: 'package-index'
+          path: index/**/*
+  deploy-to-dev:
+    runs-on: 'ubuntu-latest'
+    name: 'deploy to dev'
+    needs: package_build_check
+    environment:
+      name: dev
+      url: ${{needs.package_build_check.outputs.target-url}}
+    steps:
+      - name: fetch artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: 'package-index'
+          path: './index'
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: arn:aws:iam::699250785121:role/githubuser_role-dev
+          aws-region: us-east-1
+      - name: upload web contents
+        run: aws s3 sync ./index s3://dev.pypi.opentrons.com/${{github.ref_name}}

--- a/.github/workflows/tools.yaml
+++ b/.github/workflows/tools.yaml
@@ -110,6 +110,9 @@ jobs:
     runs-on: 'ubuntu-latest'
     name: 'deploy to dev'
     needs: package_build_check
+    permissions:
+      id-token: write
+      contents: read
     environment:
       name: dev
       url: ${{needs.package_build_check.outputs.target-url}}

--- a/tools/builder/generate_index/orchestrate.py
+++ b/tools/builder/generate_index/orchestrate.py
@@ -35,7 +35,13 @@ def generate_for_distributions(
     Params
     ------
     index_root_url: a URL where the index will be hosted - necessary for writing
-                    nice urls
+                    absolute urls to packages. This should be a domain or a domain
+                    plus path under which the index as a whole will be served. This
+                    will typically be under another /simple directory. For instance,
+                    if you pass pypi.opentrons.com as index_root_url, everything
+                    will be generated so that the index root is at
+                    pypi.opentrons.com/simple/index.html, and packages are at
+                    pypi.opentrons.com/simple/packagename/.
     index_root_path: The path to generate the index in. The index will be generated
                      such that if you run a static webserver with index_root as the
                      served directory, the resulting server will be PEP503 compliant.
@@ -81,37 +87,39 @@ def simple_url_from_index_url(index_url: str) -> str:
 
 
 def package_dirs_from_names(
-    root_path: Path, package_names: Iterable[str]
+    index_root_path: Path, package_names: Iterable[str]
 ) -> Iterator[Path]:
-    return (simple_root_from_index_root(root_path) / name for name in package_names)
+    return (
+        simple_root_from_index_root(index_root_path) / name for name in package_names
+    )
 
 
 def generate_simple_index_dir(
     index_root_url: str, index_root_path: Path, package_dirs: Iterable[Path]
 ) -> list[Path]:
-    simple_root = simple_root_from_index_root(index_root_path)
-    simple_root.mkdir(parents=True, exist_ok=True)
-    simple_url = simple_url_from_index_url(index_root_url)
-    root_index_contents = generate_root(simple_url, index_root_path, package_dirs)
-    root_index_path = simple_root / "index.html"
-    with open(root_index_path, "w") as root_index:
-        root_index.write(root_index_contents)
-    return [simple_root, root_index_path]
+    simple_fs_root = simple_root_from_index_root(index_root_path)
+    simple_fs_root.mkdir(parents=True, exist_ok=True)
+    simple_url_root = simple_url_from_index_url(index_root_url)
+    simple_root_index_contents = generate_root(
+        simple_url_root, simple_fs_root, package_dirs
+    )
+    simple_root_index_path = simple_fs_root / "index.html"
+    with open(simple_root_index_path, "w") as simple_root_index:
+        simple_root_index.write(simple_root_index_contents)
+    return [simple_fs_root, simple_root_index_path]
 
 
 def generate_and_fill_package_dir(
     index_root_url: str, index_root_path: Path, package_name: str, dists: set[Path]
 ) -> list[Path]:
-    simple_root = simple_root_from_index_root(index_root_path)
-    package_dir = simple_root / package_name
+    simple_fs_root = simple_root_from_index_root(index_root_path)
+    package_dir = simple_fs_root / package_name
     package_dir.mkdir(parents=True, exist_ok=True)
     dists_in_package = list(copy_dists_to_leaf(package_dir, dists))
-    simple_url = simple_url_from_index_url(index_root_url)
-    package_url = urljoin(simple_url, f"{package_dir.name}/")
-    print(package_url)
+    simple_root_url = simple_url_from_index_url(index_root_url)
+    package_url = urljoin(simple_root_url, f"{package_dir.name}/")
     leaf_index_contents = generate_leaf(
-        urljoin(simple_url, f"{package_dir.name}/"),
-        simple_root,
+        package_url,
         package_dir,
         dists_in_package,
     )

--- a/tools/builder/generate_index/package_leaf.py
+++ b/tools/builder/generate_index/package_leaf.py
@@ -10,7 +10,6 @@ from airium import Airium  # type: ignore[import]
 
 def generate(
     package_url: str,
-    index_root: Path,
     package_path: Path,
     distributions: Iterable[Path],
 ) -> str:
@@ -18,9 +17,8 @@ def generate(
 
     Params
     ------
-    root: the path to the actual root of index, i.e. what gets served at /
-    package_directory: the path to the package directory
-    package_name: the canonical name of the package
+    package_url: the url that locates the package directory
+    package_path: the path to the package directory
     distributions: iterable of the files to serve for the package. these paths should be true
                    filesystem paths (we need to read the files to get their hex digests) and
                    should be in the package directory.

--- a/tools/builder/generate_index/root_index.py
+++ b/tools/builder/generate_index/root_index.py
@@ -7,16 +7,18 @@ from airium import Airium  # type: ignore[import]
 
 
 def generate(
-    index_root_url: str, index_root_path: Path, package_dirs: Iterable[Path]
+    simple_root_url: str, simple_root_path: Path, package_dirs: Iterable[Path]
 ) -> str:
     """Generate a PEP503 compliant simple index root html file.
 
     Params
     ------
-    index_root_url: the url of the index's simple api
-    index_root_path: the path to the actual root of the index, i.e. what gets served at /
-    package_directory: the path to the package directory
-    package_name: the canonical name of the package
+    simple_root_url: the url of the index's simple api, e.g. pypi.opentrons.com/simple
+    simple_root_path: the path to the actual root of the simple index, i.e. what gets served
+                     at the simple_root_url, i.e. /path/to/opentrons-python-packages/index/simple
+    package_directory: the path to the package directory, i.e.
+                     /path/to/opentrons-python-packages/index/simple/package
+    package_name: the canonical name of the package, i.e. pandas for pandas
     distributions: iterable of the files to serve for the package. these paths should be true
                    filesystem paths (we need to read the files to get their hex digests) and
                    should be in the package directory.
@@ -36,7 +38,7 @@ def generate(
                 with idx.a(
                     href=str(
                         urljoin(
-                            index_root_url, str(package.relative_to(index_root_path))
+                            simple_root_url, str(package.relative_to(simple_root_path))
                         )
                     )
                 ):

--- a/tools/tests/builder/generate_index/test_package_leaf.py
+++ b/tools/tests/builder/generate_index/test_package_leaf.py
@@ -30,7 +30,6 @@ def test_generate(
 ) -> None:
     index = package_leaf.generate(
         "http://localhost/simple/pyudev/",
-        index_path,
         index_pyudev_package_dir,
         index_pyudev_distributions,
     )


### PR DESCRIPTION
We were adding simple twice accidentally. Now we should not.

Once this PR is deployed, you should be able to download pandas by doing

`pip download -i dev.pypi.opentrons.com/fixup-url-setting/simple/ --no-deps --platform-tag=linux_armv7l --python-version=3.10 pandas`